### PR TITLE
Temporary exact SmolTalk token count

### DIFF
--- a/.openai_tmp_hf_links.md
+++ b/.openai_tmp_hf_links.md
@@ -1,0 +1,1 @@
+Trigger exact SmolTalk token count.


### PR DESCRIPTION
Temporary PR used only to run the exact Hugging Face dataset/tokenizer counting workflow. It will be closed and cleaned up after retrieving the result.